### PR TITLE
Update mouseEvents list

### DIFF
--- a/project/packages/core/src/hooks/useRegisterEvents.ts
+++ b/project/packages/core/src/hooks/useRegisterEvents.ts
@@ -39,6 +39,7 @@ const mouseEvents: Array<keyof MouseCaptorEvents> = [
   "mouseup",
   "mousedown",
   "mousemove",
+  "mousemovebody",
   "doubleClick",
   "wheel",
 ];


### PR DESCRIPTION
Sigma.js has added a `mousemovebody` MouseCaptorEvent that should be accessible through the `useRegisterEvents` hook.