### PR TITLE
[core,examples] Fixes #48

### DIFF
--- a/project/packages/core/src/components/SigmaContainer.tsx
+++ b/project/packages/core/src/components/SigmaContainer.tsx
@@ -82,6 +82,7 @@ const SigmaContainerComponent = (
     if (containerRef.current !== null) {
       const sigGraph = graph ? (typeof graph === "function" ? new graph() : graph) : new Graph();
       instance = new Sigma(sigGraph, containerRef.current, { allowInvalidContainer: true, ...sigmaSettings.current });
+      if (sigma) instance.getCamera().setState(sigma.getCamera().getState());
     }
     setSigma(instance);
 

--- a/project/packages/examples/src/routing.tsx
+++ b/project/packages/examples/src/routing.tsx
@@ -7,6 +7,7 @@ import { EventsView } from "./views/events";
 import { MultipleView } from "./views/multiple";
 import { CustomRenderView } from "./views/custom-render";
 import { MultiDirectedGraphView } from "./views/multidirectedgraph";
+import { UpdatedGraphReferenceView } from "./views/updatedgraphreference";
 import { ExternalView } from "./views/external";
 
 export const Routing: FC = () => {
@@ -18,6 +19,7 @@ export const Routing: FC = () => {
       <Route path="/multiple" element={<MultipleView />} />
       <Route path="/custom-render" element={<CustomRenderView />} />
       <Route path="/multidirectedgraph" element={<MultiDirectedGraphView />} />
+      <Route path="/updatedgraphreference" element={<UpdatedGraphReferenceView />} />
       <Route path="/external" element={<ExternalView />} />
     </Routes>
   );

--- a/project/packages/examples/src/views/home.tsx
+++ b/project/packages/examples/src/views/home.tsx
@@ -37,6 +37,12 @@ export const HomeView: FC = () => {
           Instantiate a MultiDirectedGraph on SigmaContainer
         </li>
         <li>
+          <Link to="/updatedgraphreference" title="Updated graph reference">
+            Updated graph reference
+          </Link>{" "}
+          Update graph instance during lifecycle of react-sigma
+        </li>
+        <li>
           <Link to="/external" title="External">
             External control
           </Link>{" "}

--- a/project/packages/examples/src/views/multidirectedgraph.tsx
+++ b/project/packages/examples/src/views/multidirectedgraph.tsx
@@ -3,24 +3,24 @@ import { MultiDirectedGraph } from "graphology";
 
 import { SigmaContainer, useLoadGraph } from "@react-sigma/core";
 
+const MyGraph: React.FC = () => {
+  const loadGraph = useLoadGraph();
+
+  useEffect(() => {
+    // Create the graph
+    const graph = new MultiDirectedGraph();
+    graph.addNode("A", { x: 0, y: 0, label: "Node A", size: 10 });
+    graph.addNode("B", { x: 1, y: 1, label: "Node B", size: 10 });
+    graph.addEdgeWithKey("rel1", "A", "B", { label: "REL_1" });
+    graph.addEdgeWithKey("rel2", "A", "B", { label: "REL_2" });
+
+    loadGraph(graph);
+  }, [loadGraph]);
+
+  return null;
+};
+
 export const MultiDirectedGraphView: FC = () => {
-  const MyGraph: React.FC = () => {
-    const loadGraph = useLoadGraph();
-
-    useEffect(() => {
-      // Create the graph
-      const graph = new MultiDirectedGraph();
-      graph.addNode("A", { x: 0, y: 0, label: "Node A", size: 10 });
-      graph.addNode("B", { x: 1, y: 1, label: "Node B", size: 10 });
-      graph.addEdgeWithKey("rel1", "A", "B", { label: "REL_1" });
-      graph.addEdgeWithKey("rel2", "A", "B", { label: "REL_2" });
-
-      loadGraph(graph);
-    }, [loadGraph]);
-
-    return null;
-  };
-
   return (
     <SigmaContainer graph={MultiDirectedGraph} settings={{ renderEdgeLabels: true }}>
       <MyGraph />

--- a/project/packages/examples/src/views/updatedgraphreference.tsx
+++ b/project/packages/examples/src/views/updatedgraphreference.tsx
@@ -1,0 +1,32 @@
+import { FC, useEffect, useState } from "react";
+import { MultiDirectedGraph } from "graphology";
+
+import { SigmaContainer } from "@react-sigma/core";
+
+function getGraph() {
+  // Create the graph
+  const graph = new MultiDirectedGraph();
+  graph.addNode("A", { x: 0, y: 0, label: "Node A", size: 10 });
+  graph.addNode("B", { x: 1, y: 1, label: "Node B", size: 10 });
+  graph.addEdgeWithKey("rel1", "A", "B", { label: "REL_1" });
+  graph.addEdgeWithKey("rel2", "A", "B", { label: "REL_2" });
+  return graph;
+}
+
+export const UpdatedGraphReferenceView: FC = () => {
+  const [graph, setGraph] = useState<MultiDirectedGraph>(getGraph());
+
+  useEffect(() => {
+    const intervalId = setInterval(() => {
+      setGraph(getGraph());
+    }, 1000);
+
+    return () => {
+      clearInterval(intervalId);
+    }
+  }, [])
+
+  return (
+    <SigmaContainer graph={graph} settings={{ renderEdgeLabels: true }} />
+  );
+};


### PR DESCRIPTION
Details:
- Adds new example that respawn the graph every 1000ms
- In SigmaContainer, when reinstanciating Sigma, if a previous instance exists, preserves its camera's state
- In examples/multidirectedgraph, declares MyGraph component outside of MultiDirectedGraphView component, to prevent it to be reinstanciated at each render