### PR TITLE
Fix drag n drop for see whole graph button

### DIFF
--- a/website/src/components/example/DragNdrop.tsx
+++ b/website/src/components/example/DragNdrop.tsx
@@ -66,7 +66,6 @@ const DragNdrop: FC = () => {
             sigma.getGraph().setNodeAttribute(draggedNode, "y", pos.y);
 
             // Prevent sigma to move camera:
-            e.preventSigmaDefault();
             e.original.preventDefault();
             e.original.stopPropagation();
           }

--- a/website/src/components/example/DragNdrop.tsx
+++ b/website/src/components/example/DragNdrop.tsx
@@ -61,7 +61,7 @@ const DragNdrop: FC = () => {
         touchmove: (e) => {
           if (draggedNode) {
             // Get new position of node
-            const pos = sigma.viewportToGraph(e);
+            const pos = sigma.viewportToGraph(e.touches[0]);
             sigma.getGraph().setNodeAttribute(draggedNode, "x", pos.x);
             sigma.getGraph().setNodeAttribute(draggedNode, "y", pos.y);
 

--- a/website/src/components/example/DragNdrop.tsx
+++ b/website/src/components/example/DragNdrop.tsx
@@ -22,11 +22,15 @@ const DragNdrop: FC = () => {
           if (draggedNode) {
             setDraggedNode(null);
             sigma.getGraph().removeNodeAttribute(draggedNode, "highlighted");
+            
+            // Reset the bounding box around the whole graph
+            // so that a "See whole graph" Zoom control button
+            // would include dragged nodes if pressed.
+            sigma.setCustomBBox(sigma.getBBox());
           }
         },
         mousedown: (e) => {
-          // Disable the autoscale at the first down interaction
-          if (!sigma.getCustomBBox()) sigma.setCustomBBox(sigma.getBBox());
+          
         },
         mousemove: (e) => {
           if (draggedNode) {
@@ -45,11 +49,14 @@ const DragNdrop: FC = () => {
           if (draggedNode) {
             setDraggedNode(null);
             sigma.getGraph().removeNodeAttribute(draggedNode, "highlighted");
+            // Reset the bounding box around the whole graph
+            // so that a "See whole graph" Zoom control button
+            // would include dragged nodes if pressed.
+            sigma.setCustomBBox(sigma.getBBox());
           }
         },
         touchdown: (e) => {
-          // Disable the autoscale at the first down interaction
-          if (!sigma.getCustomBBox()) sigma.setCustomBBox(sigma.getBBox());
+          
         },
         touchmove: (e) => {
           if (draggedNode) {


### PR DESCRIPTION
When I tried using some of the Drag N Drop code, I discovered that it caused a problem when dragging a node and then clicking the "See whole graph" button in the Zoom control.  Basically, the dragged out node would not be included in the view after the "See whole graph" button is clicked.  This is because it needs to update the custom bounded box after the dragged node is released.  So I fixed this code.  

I also fixed 2 minor issues that prevented the example code from compiling, both involving touch events.